### PR TITLE
Add Map page object

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.pytest_cache/
+
 *.pyc
+*.log

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -56,10 +56,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:009d8865916766f7f452880d08ff94ed4c5445011a3deaac67543b82bdb0b9ee",
-                "sha256:97599c45a1ddfe9ab0a0cba889b7f214b3e310b703f176a0610c0b54e207cc04"
+                "sha256:10687fc53eeb3518e01a0ac84d3d711da623d3298a3039459d3f649927c4a270",
+                "sha256:b23a0d7da0247200fe83c67c34de9d7599ad404106367313d8e65e04174d0b4b"
             ],
-            "version": "==1.7.1"
+            "version": "==1.7.2"
         },
         "urllib3": {
             "hashes": [

--- a/dangerbot/__main__.py
+++ b/dangerbot/__main__.py
@@ -1,10 +1,9 @@
 import argparse
 
 
-parser = argparse.ArgumentParser(
-    prog="DangerBot",
-    description="A script that plays Urban Dead in order to update the wiki"
-    )
+parser = argparse.ArgumentParser(prog="DangerBot",
+                                 description="A script that plays Urban Dead in order to update the wiki")
+
 parser.add_argument("command", choices=['scout', 'report'],
                     help="scout determines the state of the world; report uses the logs to update the wiki")
 

--- a/dangerbot/logger.py
+++ b/dangerbot/logger.py
@@ -1,0 +1,9 @@
+import logging
+
+logging.basicConfig(
+                    format='%(asctime)s.%(msecs)03d %(levelname)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    filename='dangerbot.log'
+                   )
+
+logger = logging.getLogger('dangerbot')

--- a/dangerbot/page/map.py
+++ b/dangerbot/page/map.py
@@ -1,0 +1,139 @@
+import re
+from bs4 import BeautifulSoup as BeautifulSoup
+from word2number.w2n import word_to_num
+
+from dangerbot.logger import logger
+
+BARRICADE_CAPTURE = (
+                        r'(?P<open>wide open)|'
+                        r'(?P<secured>doors secured)|'
+                        r'(?P<loose>loosely barricaded)|'
+                        r'(?P<light>lightly barricaded)|'
+                        r'(?P<quite_strong>quite strongly barricaded)|'
+                        r'(?P<very_strong>very strongly barricaded)|'
+                        r'(?P<heavy>heavily barricaded)|'
+                        r'(?P<very_heavy>very heavily barricaded)|'
+                        r'(?P<extremely_heavy>extremely heavily barricaded)'
+                    )
+HP_CAPTURE = r'(\d+) Hit Points?'
+AP_CAPTURE = r'(\d+) Action Points?'
+XP_CAPTURE = r'(\d+) Experience Points?'
+ZOMBIES_CAPTURE = r'There (is|are) (?P<count>[^.]+) zombies?'
+BODIES_CAPTURE = r'There (is|are) (?P<count>[^.]+) dead (body|bodies)'
+
+
+class Map(object):
+    def __init__(self, html="", raise_exceptions=False):
+        super(Map, self).__init__()
+        self._html = BeautifulSoup(html, 'html.parser')
+        self._player_node = None
+        self._environment_node = None
+        self._raise = raise_exceptions
+
+    def __repr__(self):
+        return "Map[{}]".format(self.location())
+
+    def _raise_or_log(self, msg, node):
+        text = "{} Node[{}]".format(msg, node.get_text())
+        if self._raise:
+            raise Exception(text)
+        else:
+            logger.warn(text)
+
+    def _element(self, selector):
+        """Return an HTML node by css selector. The selector must be present and should describe a unique element"""
+        return self._html.select(selector)[0]
+
+    def _player(self):
+        if self._player_node is None:
+            self._player_node = self._element('.cp .gt')
+        return self._player_node
+
+    def _environment(self):
+        if self._environment_node is None:
+            self._environment_node = self._element('.gp .gt')
+        return self._environment_node
+
+    def _match_text(self, node, regex, force_match=True):
+        m = re.search(regex, node.get_text())
+        if force_match and m is None:
+            self._raise_or_log('Pattern not found for "{}"'.format(regex), node)
+        return m
+
+    def player(self):
+        return self._player().a.string
+
+    def getHP(self):
+        hp = self._match_text(self._player(), HP_CAPTURE)
+        return int(hp.group(1))
+
+    def getAP(self):
+        ap = self._match_text(self._player(), AP_CAPTURE)
+        return int(ap.group(1))
+
+    def getXP(self):
+        xp = self._match_text(self._player(), XP_CAPTURE)
+        return int(xp.group(1))
+
+    def location(self):
+        return self._environment().b.string
+
+    def coordinates(self):
+        current_td = self._element('table.c td > input[type="submit"]').parent
+        value = '999-999'
+        offset = (0, 0)
+        for e in current_td.next_siblings:
+            if e.name == 'td':
+                value = e.form.input['value']
+                offset = (-1, 0)
+                break
+        if offset == (0, 0):
+            for e in current_td.previous_siblings:
+                if e.name == 'td':
+                    value = e.form.input['value']
+                    offset = (1, 0)
+        if offset == (0, 0):
+            self._raise_or_log('Cannot determine location', current_td)
+        coords = tuple(map(int, value.split('-')))
+        return (coords[0] + offset[0], coords[1])
+
+    def barricade_level(self):
+        level = self._match_text(self._environment(), BARRICADE_CAPTURE, force_match=False)
+        if level is None:
+            return None
+        else:
+            groups = level.groupdict().items()
+            for lvl, match in groups:
+                if match is not None:
+                    return lvl.upper()
+        self._raise_or_log('Unable to determine barricade level', self._environment())
+
+    def count_dead(self):
+        match = self._match_text(self._environment(), BODIES_CAPTURE, force_match=False)
+        count = -1
+        if match is None:
+            count = 0
+        elif match.group('count') == 'a':
+            count = 1
+        elif match.group('count') is not None:
+            count = word_to_num(match.group('count'))
+
+        if count == -1 or count is None:
+            count = None
+            self._raise_or_log('Unable to determine body count', self._environment())
+        return count
+
+    def count_zombies(self):
+        match = self._match_text(self._environment(), ZOMBIES_CAPTURE, force_match=False)
+        count = -1
+        if match is None:
+            count = 0
+        elif match.group('count') == 'a lone':
+            count = 1
+        elif match.group('count') is not None:
+            count = word_to_num(match.group('count'))
+
+        if count == -1 or count is None:
+            count = None
+            self._raise_or_log('Unable to determine body count', self._environment())
+        return count

--- a/dangerbot/walker.py
+++ b/dangerbot/walker.py
@@ -2,7 +2,7 @@ import requests
 from os import path
 from dangerbot.paths import PATHS
 from bs4 import BeautifulSoup as Soup
-#using BeautifulSoup4 to parse page data this might change if selenium proves to be easier to get this info from
+# using BeautifulSoup4 to parse page data this might change if selenium proves to be easier to get this info from
 s = requests.session()
 
 
@@ -22,9 +22,10 @@ def getPaths():
         burbs.append(new_burb.set_plan(item))
     return burbs
 
+
 class Suburb:
     plan = []
-    ## This is the Dictionary that will convert move directions into coodinates
+    # This is the Dictionary that will convert move directions into coodinates
     dirs = {'U': [-1, 0], 'U-R': [-1, 1], 'U-L': [-1, -1], 'R': [0, 1], 'L': [0, -1], 'D': [1, 0]}
 
     def set_plan(self, moves_list):
@@ -42,12 +43,12 @@ class Walker:
     def __init__(self):
         #   online flag to allow for playing even when bot can't connect to the wiki (before wiki access is built)
         self.online = False
-        #name of current character
+        # name of current character
         self.name = ''
         #   is the character currently dead
         self.is_dead = False
-        #   Character Position
-        self.pos = [0,0]
+        #   Character position
+        self.pos = [0, 0]
         #   Character AP
         self.ap = 0
         #   Place name, building name, to identify which DangerReport page to update
@@ -55,23 +56,30 @@ class Walker:
         #   building_flag   this identifies if this is a building, and so will need a report and can be caded
         self.building = False
         #   the position to move to
-        self.new_pos = [0,0]
+        self.new_pos = [0, 0]
         #   suburb name, some locations names are used more than once. in those cases the suburb is needed to properly create the
         self.sub = ""
 
-
-        #number of walking or resting corpses
+        # number of walking or resting corpses
         self.zed = 0
         self.ded = 0
-        ## This is the dictionary that i will check against the building description string.
-        self.b = {'wide open': -1, "doors secured": 0, 'loosely barricaded': 1, 'lightly barricaded': 2, 'quite strongly barricaded': 3,
-             'very strongly barricaded': 4, 'heavily barricaded': 5, 'very heavily barricaded': 6,
-             'extremely heavily barricaded': 7}
+        # This is the dictionary that i will check against the building description string.
+        self.b = {
+            'wide open': -1,
+            "doors secured": 0,
+            'loosely barricaded': 1,
+            'lightly barricaded': 2,
+            'quite strongly barricaded': 3,
+            'very strongly barricaded': 4,
+            'heavily barricaded': 5,
+            'very heavily barricaded': 6,
+            'extremely heavily barricaded': 7
+        }
         self.cade = -1
         self.burb_path = getPaths()
         # soup = Soup()
 
-        ## This is the index of the burb-path that will be taken in each suburb
+        # This is the index of the burb-path that will be taken in each suburb
         self.malton = """7,0,5,0,5,0,5,0,5,0
 1,0,4,0,4,0,4,0,4,0
 1,0,4,0,4,0,4,0,4,0
@@ -88,7 +96,6 @@ class Walker:
             for j in range(10):
                 self.malton[i][j] = int(self.malton[i][j])
 
-
     def get_events(self):
         events = self.soup.ul.get_text().split('\n')
         relevent_events = []
@@ -103,7 +110,6 @@ class Walker:
         not_pos = not_pos.split('-')
         for index in range(2):
             self.pos[index] = int(not_pos[index])
-
 
     # TODO: update()     this will do the updating of the walker
     def update(self):
@@ -120,16 +126,14 @@ class Walker:
         if 'a ' in self.loc:
             self.loc += ' ' + str(self.pos)
 
-
-
-    #TODO: read()       this will read the web page and record the surroundings
+    # TODO: read()       this will read the web page and record the surroundings
     def read(self):
         text = self.soup.find_all(class_='gt')
         info_box = text[1]
 
         if 'The building' in info_box.get_text():
             self.building = True
-            for level,val in self.b.items():
+            for level, val in self.b.items():
                 if level in info_box.get_text():
                     self.cade = val
 
@@ -138,7 +142,7 @@ class Walker:
         self.update()
         return
 
-    #TODO:  write_log()     this will write all info to a log file
+    # TODO:  write_log()     this will write all info to a log file
     def write_log(self):
         log_string = f"Log of {self.name} at {self.pos}\nLocation: {self.loc} in {self.sub}\n"
         log_string += f"AP: {self.ap}   Dead? {self.is_dead}\n"
@@ -148,19 +152,18 @@ class Walker:
 
         return log_string
 
-
-    #TODO: write()      this will write the info found into a log that can be transitioned into writing into the wiki
+    # TODO: write()      this will write the info found into a log that can be transitioned into writing into the wiki
     def write(self):
         log_string = self.write_log()
         print(log_string)
         print('----------\n')
 
-    #TODO: move()        write this for real
+    # TODO: move()        write this for real
     def move(self):
         #   determine move to make based on current suburb
         suburb = [self.pos[0]//10, self.pos[1]//10]
         moveplan = self.malton[suburb[0]][suburb[1]]
-        sub = 10 * suburb[0] + suburb[1]
+        # sub = 10 * suburb[0] + suburb[1]
 
         #   determine exact move based on current square
         square = [self.pos[0] % 10, self.pos[1] % 10]
@@ -179,8 +182,7 @@ class Walker:
             self.move()
         return
 
-
-    #TODO: move2() this is the testing function
+    # TODO: move2() this is the testing function
     def move2(self):
         #   determine move to make based on current suburb
         suburb = [self.pos[0]//10, self.pos[1]//10]
@@ -198,7 +200,7 @@ class Walker:
         print(f'location = {self.pos} sub = {sub},\t\tMove plan {moveplan}\tMove {moves}')
         return sub
 
-    #TODO: login()
+    # TODO: login()
     def login(self, character):
         url_string = "http://www.urbandead.com/map.cgi?username=MaltonMapper" + character + "&password=urbandead"
         r = s.get(url_string)
@@ -225,9 +227,9 @@ class Walker:
 
 def _test_write():
     walker1 = Walker()
-    walker1.login2(path.abspath(path.join('data', 'testFile.html')))
+    walker1.login2(path.abspath(path.join('data', 'swansborough-park.html')))
     walker1.write()
-    walker1.login2(path.abspath(path.join('data', 'testFile2.html')))
+    walker1.login2(path.abspath(path.join('data', 'warehouse.html')))
     walker1.write()
 
 

--- a/data/clough-towers-bino-n.html
+++ b/data/clough-towers-bino-n.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Whittenside</td></tr>
+<tr><td class="b c5"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-96"><input type="submit" class="md" value="Brymer Drive"></form></td><td class="b c2"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-96"><input type="submit" class="md" value="the Bellamy
+Building"></form></td><td class="b c9"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-96"><input type="submit" class="md" value="St Francis's
+Hospital"></form></td></tr>
+<tr><td class="b c12"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-97"><input type="submit" class="md" value="Sprackling
+Square
+Police
+Dept"></form></td><td class="b cx"><input type="submit" class="md" value="Clough Towers"></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-97"><input type="submit" class="md" value="Stroude
+Crescent"></form></td></tr>
+<tr><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-98"><input type="submit" class="md" value="Skilton
+Crescent"></form></td><td class="b c27"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-98"><input type="submit" class="md" value="Club Adey"></form></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-98"><input type="submit" class="md" value="Red Park"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>0</b> Experience Points. You have <b>41</b> Action Points remaining.</div><div class="gthome">You have no safehouse set. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="89"><input type="hidden" name="homey" value="97"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are inside <b>Clough Towers</b>. The building has been very heavily barricaded.<br><br>Somebody has spraypainted <i>Dr Manson has excellent group association pedigree</i> onto a wall.</div><p class="gamemessage"><b>You look out over the blocks to the  of the building.</b><table class="c bn"><tr></table><b></b></p><p>Possible actions:</p>  <form action="map.cgi?out" method="post" class="a"><input class="m" type="submit" value="Leave Clough Towers"></form> <form action="map.cgi?jump" method="post" class="a"><input class="m" type="submit" value="Jump from a window"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='b'> the barricades</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m">&nbsp;looking&nbsp;<select name="d"><option value="n">north<option value="ne">north-east<option value="e">east<option value="se">south-east<option value="s">south<option value="sw">south-west<option value="w">west<option value="nw">north-west</select></form> <p>You are 6% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/clough-towers-bino-ne.html
+++ b/data/clough-towers-bino-ne.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Whittenside</td></tr>
+<tr><td class="b c5"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-96"><input type="submit" class="md" value="Brymer Drive"></form></td><td class="b c2"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-96"><input type="submit" class="md" value="the Bellamy
+Building"></form></td><td class="b c9"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-96"><input type="submit" class="md" value="St Francis's
+Hospital"></form></td></tr>
+<tr><td class="b c12"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-97"><input type="submit" class="md" value="Sprackling
+Square
+Police
+Dept"></form></td><td class="b cx"><input type="submit" class="md" value="Clough Towers"></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-97"><input type="submit" class="md" value="Stroude
+Crescent"></form></td></tr>
+<tr><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-98"><input type="submit" class="md" value="Skilton
+Crescent"></form></td><td class="b c27"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-98"><input type="submit" class="md" value="Club Adey"></form></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-98"><input type="submit" class="md" value="Red Park"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>0</b> Experience Points. You have <b>43</b> Action Points remaining.</div><div class="gthome">You have no safehouse set. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="89"><input type="hidden" name="homey" value="97"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are inside <b>Clough Towers</b>. The building has been very heavily barricaded.<br><br>Somebody has spraypainted <i>Dr Manson has excellent group association pedigree</i> onto a wall.</div><p class="gamemessage"><b>You look out over the blocks to the  of the building.</b><table class="c bn"><tr></table><b></b></p><p>Possible actions:</p>  <form action="map.cgi?out" method="post" class="a"><input class="m" type="submit" value="Leave Clough Towers"></form> <form action="map.cgi?jump" method="post" class="a"><input class="m" type="submit" value="Jump from a window"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='b'> the barricades</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m">&nbsp;looking&nbsp;<select name="d"><option value="n">north<option value="ne">north-east<option value="e">east<option value="se">south-east<option value="s">south<option value="sw">south-west<option value="w">west<option value="nw">north-west</select></form> <p>You are 6% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/clough-towers.html
+++ b/data/clough-towers.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Whittenside</td></tr>
+<tr><td class="b c5"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-96"><input type="submit" class="md" value="Brymer Drive"></form></td><td class="b c2"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-96"><input type="submit" class="md" value="the Bellamy
+Building"></form></td><td class="b c9"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-96"><input type="submit" class="md" value="St Francis's
+Hospital"></form></td></tr>
+<tr><td class="b c12"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-97"><input type="submit" class="md" value="Sprackling
+Square
+Police
+Dept"></form></td><td class="b cx"><input type="submit" class="md" value="Clough Towers"></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-97"><input type="submit" class="md" value="Stroude
+Crescent"></form></td></tr>
+<tr><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-98"><input type="submit" class="md" value="Skilton
+Crescent"></form></td><td class="b c27"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-98"><input type="submit" class="md" value="Club Adey"></form></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-98"><input type="submit" class="md" value="Red Park"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>0</b> Experience Points. You have <b>47</b> Action Points remaining.</div><div class="gthome">You have no safehouse set. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="89"><input type="hidden" name="homey" value="97"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are inside <b>Clough Towers</b>. The building has been very heavily barricaded.<br><br>Somebody has spraypainted <i>Dr Manson has excellent group association pedigree</i> onto a wall.</div><p>Possible actions:</p>  <form action="map.cgi?out" method="post" class="a"><input class="m" type="submit" value="Leave Clough Towers"></form> <form action="map.cgi?jump" method="post" class="a"><input class="m" type="submit" value="Jump from a window"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='b'> the barricades</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m">&nbsp;looking&nbsp;<select name="d"><option value="n">north<option value="ne">north-east<option value="e">east<option value="se">south-east<option value="s">south<option value="sw">south-west<option value="w">west<option value="nw">north-west</select></form> <p>You are 6% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/fricker-crescent-police-dept-low-ap.html
+++ b/data/fricker-crescent-police-dept-low-ap.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Miltown</td></tr>
+<tr><td class="b c0"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-93"><input type="submit" class="md" value="Ackermen Way"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-93"><input type="submit" class="md" value="Hanham Way"></form></td><td class="b c1"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-93"><input type="submit" class="md" value="Postlethwaite
+Drive"></form></td></tr>
+<tr><td class="b c38"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-94"><input type="submit" class="md" value="a warehouse"></form></td><td class="b cx"><input type="submit" class="md" value="Fricker
+Crescent
+Police
+Dept"><br><a href="profile.cgi?id=869813" class="f3">Dominica&nbsp;Bekker</a> </td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-94"><input type="submit" class="md" value="Restrick
+Crescent"></form></td></tr>
+<tr><td class="b c13"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-95"><input type="submit" class="md" value="Bisdee
+Road
+Fire
+Station"></form></td><td class="b c3"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-95"><input type="submit" class="md" value="a carpark"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-95"><input type="submit" class="md" value="Snoad Grove"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>1</b> Experience Points. <span class="apw">You have <b>7</b> Action Points remaining.</span></div><div class="gthome">Your safehouse is <b>Fricker Crescent Police Dept</b>, here.</div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are in your safehouse at <b>Fricker Crescent Police Dept</b>. The building has been extremely heavily barricaded. Also here is <a href="profile.cgi?id=869813">Dominica&nbsp;Bekker</a>.<br><br>Somebody has spraypainted <i>Can we impeach him already?</i> onto a wall.</div><p class="gamemessage"><b>You search and find nothing.</b></p><p>Possible actions:</p>  <form action="map.cgi?out" method="post" class="a"><input class="m" type="submit" value="Leave Fricker Crescent Police Dept"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form> <form action="map.cgi" method="post" class="a"><input type="text" name="speech" maxlength=255><input type="submit" class="m" value="Speak"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='869813'> Dominica&nbsp;Bekker<option value='b'> the barricades</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <form action="map.cgi?use-h" method="post" class="a"><input type="submit" value="first-aid kit" class="m">&nbsp;on&nbsp;<select name="target"><option value="">self<option value='869813'> Dominica&nbsp;Bekker</select></form> <form action="map.cgi?use-B" method="post" class="a"><input type="submit" value="radio" class="m">(27.59 MHz)<input type="hidden" name="freq" value="2759"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <p>You are 24% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars<option value="h"> first-aid kit<option value="B2759"> radio (27.59 MHz)<option value="k"> pistol clip<option value="f"> flak jacket</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/glyde-bank.html
+++ b/data/glyde-bank.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c"
+cellspacing=0>
+<tr><td colspan=3 class="sb">Miltown</td></tr>
+<tr><td class="b c5"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-90"><input type="submit" class="md" value="Beamer Drive"></form></td><td class="b c28"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-90"><input type="submit" class="md" value="the Bizzell
+Monument"></form></td><td class="b c11"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-90"><input type="submit" class="md" value="Gover Library"></form></td></tr>
+<tr><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-91"><input type="submit" class="md" value="Selley Plaza"></form></td><td class="b c21 l"><input type="submit" class="mr" value="Glyde Bank"></td><td class="b c20"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-91"><input type="submit" class="md" value="the Cartwright
+Building"></form></td></tr>
+<tr><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-92"><input type="submit" class="md" value="Wilsdon Park"></form></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-92"><input type="submit" class="md" value="Hitchcott
+Park"></form></td><td class="b c38"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-92"><input type="submit" class="md" value="a warehouse"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>1</b> Experience Points. <span class="apw">You have <b>2</b> Action Points remaining.</span></div><div class="gthome">Your safehouse is <b>Fricker Crescent Police Dept</b>, 3 blocks south. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="90"><input type="hidden" name="homey" value="91"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are standing outside <b>Glyde Bank</b>, a narrow white-stone building with arched windows. The building has been very strongly barricaded. Through the broken windows, you can see that the interior of the building has been ruined.</div><p>Possible actions:</p>  <form action="map.cgi?in" method="post" class="a"><input class="m"
+type="submit" value="Enter Glyde Bank"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m"
+value="Search the area"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select
+name="target"><option value='b'> the barricades</select>&nbsp;with&nbsp;<select
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='shotgun'> shotgun (5%, 10 dam)</option><option value='flare'> flare (2.5%, 15 dam)<option value='pipe'> metal pipe (10%, 2 dam)</option></select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <form action="map.cgi?use-h" method="post" class="a"><input type="submit" value="first-aid kit" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-r" method="post" class="a"><input type="submit" value="shotgun shell" class="m"></form> <form action="map.cgi?use-p" method="post" class="a"><input type="submit" value="length of pipe" class="m"></form> <form action="map.cgi?use-B" method="post" class="a"><input type="submit" value="radio" class="m">(27.59 MHz)<input type="hidden" name="freq" value="2759"></form> <form action="map.cgi?use-s" method="post" class="a"><input type="submit" value="shotgun" class="m">(0)</form> <p>You are 40% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars<option value="h"> first-aid kit<option value="k"> pistol clip<option value="f"> flak jacket<option value="r"> shotgun shell<option value="p"> length of pipe<option value="B2759"> radio (27.59 MHz)<option value="s0"> shotgun (0)</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/hanham-way.html
+++ b/data/hanham-way.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c"
+cellspacing=0>
+<tr><td colspan=3 class="sb">Miltown</td></tr>
+<tr><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-92"><input type="submit" class="md" value="Wilsdon Park"></form></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-92"><input type="submit" class="md" value="Hitchcott
+Park"></form></td><td class="b c38"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-92"><input type="submit" class="md" value="a warehouse"></form></td></tr>
+<tr><td class="b c0"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-93"><input type="submit" class="md" value="Ackermen Way"></form></td><td class="b c33 l"><input type="submit" class="md" value="Hanham Way"></td><td class="b c1"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-93"><input type="submit" class="md" value="Postlethwaite
+Drive"></form></td></tr>
+<tr><td class="b c38"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-94"><input type="submit" class="md" value="a warehouse"></form></td><td class="b c12"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-94"><input type="submit" class="md" value="Fricker
+Crescent
+Police
+Dept"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-94"><input type="submit" class="md" value="Restrick
+Crescent"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>1</b> Experience Points. <span class="apw">You have <b>6</b> Action Points remaining.</span></div><div class="gthome">Your safehouse is <b>Fricker Crescent Police Dept</b>, 1 block south. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="90"><input type="hidden" name="homey" value="93"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are at <b>Hanham Way</b>.<br><br>There is a dead body here.</div><p>Possible actions:</p>  <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m"
+value="Search the area"></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <form action="map.cgi?use-h" method="post" class="a"><input type="submit" value="first-aid kit" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-r" method="post" class="a"><input type="submit" value="shotgun shell" class="m"></form> <form action="map.cgi?use-p" method="post" class="a"><input type="submit" value="length of pipe" class="m"></form> <form action="map.cgi?use-B" method="post" class="a"><input type="submit" value="radio" class="m">(27.59 MHz)<input type="hidden" name="freq" value="2759"></form> <form action="map.cgi?use-s" method="post" class="a"><input type="submit" value="shotgun" class="m">(0)</form> <p>You are 40% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars<option value="h"> first-aid kit<option value="k"> pistol clip<option value="f"> flak jacket<option value="r"> shotgun shell<option value="p"> length of pipe<option value="B2759"> radio (27.59 MHz)<option value="s0"> shotgun (0)</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/kingham-drive.html
+++ b/data/kingham-drive.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c"
+cellspacing=0>
+<tr><td colspan=3 class="sb">Fryerbank</td></tr>
+<tr><td class="b c0"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="98-81"><input type="submit" class="md" value="Tidball Walk"></form></td><td class="b c8"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="99-81"><input type="submit" class="md" value="wasteland"></form><br><span class="fz">1
+zombie</span></td><tr><td class="b c38"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="98-82"><input type="submit" class="md" value="a warehouse"></form></td><td class="b c33 l"><input type="submit" class="md" value="Kingham Drive"></td><tr><td class="b c17"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="98-83"><input type="submit" class="md" value="Parr Towers"></form></td><td class="b c20"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="99-83"><input type="submit" class="md" value="the Phipps
+Building"></form></td></table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>1</b> Experience Points. You have <b>11</b> Action Points remaining.</div><div class="gthome">Your safehouse is <b>Fricker Crescent Police Dept</b>, 9 blocks west and 12 south. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="99"><input type="hidden" name="homey" value="82"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are at <b>Kingham Drive</b>.<br><br>Somebody has spraypainted <i>visit ham king for the king of all hams</i> onto a wall.</div><p>Possible actions:</p>  <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m"
+value="Search the area"></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <form action="map.cgi?use-h" method="post" class="a"><input type="submit" value="first-aid kit" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-k" method="post" class="a"><input type="submit" value="pistol clip" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-f" method="post" class="a"><input type="submit" value="flak jacket" class="m"></form> <form action="map.cgi?use-r" method="post" class="a"><input type="submit" value="shotgun shell" class="m"></form> <form action="map.cgi?use-p" method="post" class="a"><input type="submit" value="length of pipe" class="m"></form> <form action="map.cgi?use-B" method="post" class="a"><input type="submit" value="radio" class="m">(27.59 MHz)<input type="hidden" name="freq" value="2759"></form> <form action="map.cgi?use-s" method="post" class="a"><input type="submit" value="shotgun" class="m">(0)</form> <p>You are 40% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars<option value="h"> first-aid kit<option value="k"> pistol clip<option value="f"> flak jacket<option value="r"> shotgun shell<option value="p"> length of pipe<option value="B2759"> radio (27.59 MHz)<option value="s0"> shotgun (0)</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/sprackling-square-police-dept-ext.html
+++ b/data/sprackling-square-police-dept-ext.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Whittenside</td></tr>
+<tr><td class="b c3"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="87-96"><input type="submit" class="md" value="a carpark"></form></td><td class="b c5"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-96"><input type="submit" class="md" value="Brymer Drive"></form></td><td class="b c2"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-96"><input type="submit" class="md" value="the Bellamy
+Building"></form></td></tr>
+<tr><td class="b c14"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="87-97"><input type="submit" class="mr" value="Dewfall
+Cinema"></form></td><td class="b c12 l"><input type="submit" class="md" value="Sprackling
+Square
+Police
+Dept"></td><td class="b c17"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-97"><input type="submit" class="md" value="Clough Towers"></form></td></tr>
+<tr><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="87-98"><input type="submit" class="md" value="Copping Drive"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="88-98"><input type="submit" class="md" value="Skilton
+Crescent"></form></td><td class="b c27"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-98"><input type="submit" class="md" value="Club Adey"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>0</b> Experience Points. You have <b>50</b> Action Points remaining.</div><div class="gthome">You have no safehouse set. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="88"><input type="hidden" name="homey" value="97"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are standing outside <b>Sprackling Square Police Dept</b>, a derelict red-brick building split by a large, diagonal crack. The building has been very strongly barricaded.</div><p>Possible actions:</p>  <form action="map.cgi?in" method="post" class="a"><input class="m"
+type="submit" value="Enter Sprackling Square Police Dept"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='b'> the barricades</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <p>You are 6% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/st-francis-hospital.html
+++ b/data/st-francis-hospital.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
+<script type="text/javascript" src="/js/cookies.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+</head><body><table width="100%"><tr><td class="cp"><table class="c" 
+cellspacing=0>
+<tr><td colspan=3 class="sb">Miltown</td></tr>
+<tr><td class="b c13"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-95"><input type="submit" class="md" value="Bisdee
+Road
+Fire
+Station"></form></td><td class="b c3"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-95"><input type="submit" class="md" value="a carpark"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-95"><input type="submit" class="md" value="Snoad Grove"></form></td></tr>
+<tr><td class="b c2"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-96"><input type="submit" class="md" value="the Bellamy
+Building"></form></td><td class="b cx"><input type="submit" class="md" value="St Francis's
+Hospital"><br><span class="fz">1 
+zombie</span></td><td class="b c4"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-96"><input type="submit" class="md" value="Villar Park"></form></td></tr>
+<tr><td class="b c17"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="89-97"><input type="submit" class="md" value="Clough Towers"></form></td><td class="b c33"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="90-97"><input type="submit" class="md" value="Stroude
+Crescent"></form></td><td class="b c18"><form action="map.cgi" method="post">
+<input type="hidden" name="v" value="91-97"><input type="submit" class="md" value="a factory"></form></td></tr>
+</table>
+<div class="gt">You are <a href="profile.cgi?id=2307642"><b>GMClaystyle</b></a>. You have <b>50</b> Hit Points and <b>0</b> Experience Points. You have <b>40</b> Action Points remaining.</div><div class="gthome">You have no safehouse set. <form action="map.cgi?home" method="post" class="a"><input type="hidden" name="homex" value="90"><input type="hidden" name="homey" value="96"><input class="m" value="Set here" type="submit"></form></div><p>
+<a href="skills.cgi" class="y">Buy skills</a>
+<a href="contacts.cgi" class="y">Contacts</a>
+<a href="profile.cgi?mode=edit&id=2307642" class="y">Settings</a>
+<a href="map.cgi?logout" class="y">Log out</a>
+</p>
+<p>
+<a href="news.html" class="y">News</a>
+<a href="faq.html" class="y">FAQ</a>
+<a href="http://wiki.urbandead.com" class="y">Wiki</a>
+<a href="donate.html" class="y">Donate</a>
+</p>
+</td>
+<td class="gp">
+<div class="gt">You are inside <b>St Francis's Hospital</b>, dark corridors leading through abandoned wards. The doors to the street have been left wide open.<br><br>There is a lone zombie here.</div><p>Possible actions:</p>  <form action="map.cgi?out" method="post" class="a"><input class="m" type="submit" value="Leave St Francis's Hospital"></form> <form action="map.cgi?close" method="post" class="a"><input class="m" type="submit" value="Close the doors"></form> <form action="map.cgi?search" method="post" class="a"><input type="submit" class="m" 
+value="Search the area"></form> <form action="map.cgi" method="post" class="a"><input type="text" name="speech" maxlength=255><input type="submit" class="m" value="Speak"></form><br> <form action="map.cgi" method="post" class="a">
+<input type="submit" value="Attack" class="m">&nbsp;<select 
+name="target"><option value='z'> the zombie</select>&nbsp;with&nbsp;<select 
+name="weapon"><option value="punch"> punch (10%, 1 dam)</option><option value='flare'> flare (2.5%, 15 dam)</select></form><p>Inventory (click to use):</p> <form action="map.cgi?use-c" method="post" class="a"><input type="submit" value="flare gun" class="m"></form> <form action="map.cgi?use-F" method="post" class="a"><input type="submit" value="binoculars" class="m"></form> <p>You are 6% encumbered.</p><p><form action="map.cgi" method="post" class="a"><input class="m" type="submit" value="Drop"><select name="drop"><option value=""> -----<option value="c"> flare gun<option value="F"> binoculars</select> (0 AP)</form></p></td></tr></table>
+</body></html>

--- a/data/swansborough-park.html
+++ b/data/swansborough-park.html
@@ -15,7 +15,7 @@
             <td class="cp">
                 <table class="c" cellspacing=0>
                     <tr>
-                        <td colspan=3 class="sb">Roftwood</td>
+                        <td colspan=3 class="sb">swansborough</td>
                     </tr>
                     <tr>
                         <td class="b c17">

--- a/data/warehouse.html
+++ b/data/warehouse.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <!-- saved from url=(0031)http://urbandead.com/map.cgi?in -->
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>Urban Dead - The City</title><link rel="stylesheet" href="./testFile2_files/dead.css"><!--v13.45-->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>Urban Dead - The City</title><link rel="stylesheet" href="http://urbandead.com/dead.css?148"><!--v13.45-->
 <script type="text/javascript" src="./testFile2_files/cookies.js.download"></script>
 <script type="text/javascript" src="./testFile2_files/cookieconsent.min.js.download"></script>
 </head><body><table width="100%"><tbody><tr><td class="cp"><table class="c" cellspacing="0">

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,7 @@
+from os import path
+
+
+def get_html_from_file(named):
+    file_path = path.abspath(path.join('data', named + '.html'))
+    with open(file_path, 'r') as f:
+        return f.read()

--- a/tests/page/conftest.py
+++ b/tests/page/conftest.py
@@ -1,0 +1,208 @@
+import pytest
+
+
+test_html_files = [
+    (
+        'clough-towers',
+        {
+            'location': {
+                'name': 'Clough Towers',
+                'coords': (89, 97),
+                'barricade': 'VERY_HEAVY',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 47,
+                'hp': 50,
+                'xp': 0,
+            },
+        }
+    ),
+    (
+        'clough-towers-bino-n',
+        {
+            'location': {
+                'name': 'Clough Towers',
+                'coords': (89, 97),
+                'barricade': 'VERY_HEAVY',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 41,
+                'hp': 50,
+                'xp': 0,
+            },
+        }
+    ),
+    (
+        'clough-towers-bino-ne',
+        {
+            'location': {
+                'name': 'Clough Towers',
+                'coords': (89, 97),
+                'barricade': 'VERY_HEAVY',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 43,
+                'hp': 50,
+                'xp': 0,
+            },
+        }
+    ),
+    (
+        'fricker-crescent-police-dept-low-ap',
+        {
+            'location': {
+                'name': 'Fricker Crescent Police Dept',
+                'coords': (90, 94),
+                'barricade': 'EXTREMELY_HEAVY',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 7,
+                'hp': 50,
+                'xp': 1,
+            },
+        }
+    ),
+    (
+        'glyde-bank',
+        {
+            'location': {
+                'name': 'Glyde Bank',
+                'coords': (90, 91),
+                'barricade': 'VERY_STRONG',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 2,
+                'hp': 50,
+                'xp': 1,
+            }
+        }
+    ),
+    (
+        'hanham-way',
+        {
+            'location': {
+                'name': 'Hanham Way',
+                'coords': (90, 93),
+                'barricade': None,
+                'dead': 1,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 6,
+                'hp': 50,
+                'xp': 1,
+            }
+        }
+    ),
+    (
+        'kingham-drive',
+        {
+            'location': {
+                'name': 'Kingham Drive',
+                'coords': (99, 82),
+                'barricade': None,
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 11,
+                'hp': 50,
+                'xp': 1,
+            }
+        }
+    ),
+    (
+        'sprackling-square-police-dept-ext',
+        {
+            'location': {
+                'name': 'Sprackling Square Police Dept',
+                'coords': (88, 97),
+                'barricade': 'VERY_STRONG',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 50,
+                'hp': 50,
+                'xp': 0,
+            },
+        }
+    ),
+    (
+        'st-francis-hospital',
+        {
+            'location': {
+                'name': "St Francis's Hospital",
+                'coords': (90, 96),
+                'barricade': 'OPEN',
+                'dead': 0,
+                'zombies': 1,
+            },
+            'player': {
+                'name': 'GMClaystyle',
+                'ap': 40,
+                'hp': 50,
+                'xp': 0,
+            },
+        }
+    ),
+    (
+        'swansborough-park',
+        {
+            'location': {
+                'name': 'Swansborough Park',
+                'coords': (68, 53),
+                'barricade': None,
+                'dead': 3,
+                'zombies': 4,
+            },
+            'player': {
+                'name': 'MaltonMapper1',
+                'ap': 37,
+                'hp': 0,
+                'xp': 12,
+            },
+        }
+    ),
+    (
+        'warehouse',
+        {
+            'location': {
+                'name': 'a warehouse',
+                'coords': (60, 63),
+                'barricade': 'VERY_STRONG',
+                'dead': 0,
+                'zombies': 0,
+            },
+            'player': {
+                'name': 'MaltonMapper1',
+                'ap': 33,
+                'hp': 7,
+                'xp': 23,
+            },
+        }
+    ),
+]
+
+
+@pytest.fixture(params=range(len(test_html_files)), ids=lambda i:  test_html_files[i][0])
+def example_file(request):
+    return test_html_files[request.param]

--- a/tests/page/test_map.py
+++ b/tests/page/test_map.py
@@ -1,0 +1,64 @@
+from helpers import get_html_from_file
+from dangerbot.page.map import Map
+
+
+######################
+# Environment
+######################
+
+
+def test_map_location(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.location() == data['location']['name']
+
+
+def test_map_coords(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.coordinates() == data['location']['coords']
+
+
+def test_map_baracade_level(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.barricade_level() == data['location']['barricade']
+
+
+def test_map_dead_count(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.count_dead() == data['location']['dead']
+
+def test_map_zed_count(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.count_zombies() == data['location']['zombies']
+
+
+######################
+# Player Status
+######################
+
+def test_player_name(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.player() == data['player']['name']
+
+
+def test_player_ap(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.getAP() == data['player']['ap']
+
+
+def test_player_hp(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.getHP() == data['player']['hp']
+
+
+def test_player_xp(example_file):
+    file, data = example_file
+    page = Map(get_html_from_file(file), raise_exceptions=True)
+    assert page.getXP() == data['player']['xp']

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -4,14 +4,14 @@ from dangerbot.walker import Walker
 
 def test_write():
     walker1 = Walker()
-    walker1.login2(path.abspath(path.join('data', 'testFile.html')))
+    walker1.login2(path.abspath(path.join('data', 'swansborough-park.html')))
     assert walker1.write_log() == """Log of MaltonMapper1 at [67, 52]
-Location: Swansborough Park in Roftwood
+Location: Swansborough Park in swansborough
 AP: 37   Dead? True
 Zombies:  Zed: 0  Ded:0
 """
 
-    walker1.login2(path.abspath(path.join('data', 'testFile2.html')))
+    walker1.login2(path.abspath(path.join('data', 'warehouse.html')))
     assert walker1.write_log() == """Log of MaltonMapper1 at [59, 62]
 Location: a warehouse [59, 62] in Tollyton
 AP: 33   Dead? True


### PR DESCRIPTION
The map object currently understands how to interpret most of the things we are interested in.

Understands:
- player name
- player health
- player hp
- player ap
- player xp
- location name
- location coordinates
- location barricade level
- location dead body count
- location zombie count

Missing:
- location lit status
- location ruined status
- determine if a cell tower is present
- determine if a cell tower is functioning

The map object will also need to know how to generate the next action links for
- movement
- enter/leave building
- standing up from death

Misc:
- Fixed flake8 warnings